### PR TITLE
In-text equations containing dollar signs won't render

### DIFF
--- a/markdown-it-mathjax.js
+++ b/markdown-it-mathjax.js
@@ -71,6 +71,7 @@
       var afterMarker = state.src[ i + 1 ]
       if (marker === endMarker && !!/[^\d]/.test(afterMarker) && (i + 1) > startMathPos) {
         endMarkerPos = i
+        break
       }
     }
     if (endMarkerPos === -1) {

--- a/markdown-it-mathjax.js
+++ b/markdown-it-mathjax.js
@@ -69,7 +69,7 @@
     for (var i = 0; i < state.src.length; i++) {
       var marker = state.src[i]
       var afterMarker = state.src[ i + 1 ]
-      if (marker === endMarker && !!/[^\d]/.test(afterMarker) && (i + 1) > startMathPos) {
+      if (marker === endMarker && /[^\d]/.test(afterMarker) && (i + 1) > startMathPos) {
         endMarkerPos = i
         break
       }

--- a/markdown-it-mathjax.js
+++ b/markdown-it-mathjax.js
@@ -63,7 +63,16 @@
         return false
       }
     }
+
+    // find endMarkerPos
     var endMarkerPos = state.src.indexOf(endMarker, startMathPos)
+    for (var i = 0; i < state.src.length; i++) {
+      var marker = state.src[i]
+      var afterMarker = state.src[ i + 1 ]
+      if (marker === endMarker && !!/[^\d]/.test(afterMarker) && (i + 1) > startMathPos) {
+        endMarkerPos = i
+      }
+    }
     if (endMarkerPos === -1) {
       return false
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-it-mathjax",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "markdown-it-mathjax.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,9 @@ describe('Tex in-line math', function () {
   it('should work properly', function () {
     md.render('$1 *2* 3$').should.eql('<p>\\(1 *2* 3\\)</p>\n')
   })
+  it('can handle dollors in formulas', function () {
+    md.render('$sum_{$4}^2$').should.eql('<p>\\(sum_{$4}^2\\)</p>\n')
+  })
   it('should not be processed if space after first marker', function () {
     md.render('$ 1 *2* 3$').should.eql('<p>$ 1 <em>2</em> 3$</p>\n')
   })
@@ -17,9 +20,6 @@ describe('Tex in-line math', function () {
   })
   it('should not be processed if number around', function () {
     md.render('$1 *2* 3$5').should.eql('<p>$1 <em>2</em> 3$5</p>\n')
-  })
-  it('can handle dollors in subscript', function () {
-    md.render('$sum_{$4}^2$').should.eql('<p>\\(sum_{$4}^2\\)</p>\n')
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -9,10 +9,10 @@ describe('Tex in-line math', function () {
   it('should work properly', function () {
     md.render('$1 *2* 3$').should.eql('<p>\\(1 *2* 3\\)</p>\n')
   })
-  it('can handle dollors in formulas', function () {
+  it('can handle dollars in formulas', function () {
     md.render('$sum_{$4}^2$').should.eql('<p>\\(sum_{$4}^2\\)</p>\n')
   })
-  it('can handle multiple dollors in formulas', function () {
+  it('can handle multiple dollars in formulas', function () {
     md.render('if $a^{$2.00}$ then $b^{$3.00}$').should.eql('<p>if \\(a^{$2.00}\\) then \\(b^{$3.00}\\)</p>\n')
   })
   it('should not be processed if space after first marker', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,9 @@ describe('Tex in-line math', function () {
   it('should not be processed if number around', function () {
     md.render('$1 *2* 3$5').should.eql('<p>$1 <em>2</em> 3$5</p>\n')
   })
+  it('can handle dollors in subscript', function () {
+    md.render('$sum_{$4}^2$').should.eql('<p>\\(sum_{$4}^2\\)</p>\n')
+  })
 })
 
 describe('Tex displayed math', function () {
@@ -59,8 +62,3 @@ describe('Custom wrapping', function () {
   })
 })
 
-describe('describe from test...LaTeX in-line math', function () {
-  it('should work when escaped $ used for dollars', function () {
-    md.render('$sum_{$4}^2$').should.eql('<p>\\(sum_{$4}^2\\)</p>\n')
-  })
-})

--- a/test/test.js
+++ b/test/test.js
@@ -61,4 +61,3 @@ describe('Custom wrapping', function () {
     md.render('\\begin{section}1 *2* 3\\end{section}').should.eql('<p><span>\\begin{section}1 *2* 3\\end{section}</span></p>\n')
   })
 })
-

--- a/test/test.js
+++ b/test/test.js
@@ -58,3 +58,9 @@ describe('Custom wrapping', function () {
     md.render('\\begin{section}1 *2* 3\\end{section}').should.eql('<p><span>\\begin{section}1 *2* 3\\end{section}</span></p>\n')
   })
 })
+
+describe('describe from test...LaTeX in-line math', function () {
+  it('should work when escaped $ used for dollars', function () {
+    md.render('$sum_{$4}^2$').should.eql('<p>\\(sum_{$4}^2\\)</p>\n')
+  })
+})

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,9 @@ describe('Tex in-line math', function () {
   it('can handle dollors in formulas', function () {
     md.render('$sum_{$4}^2$').should.eql('<p>\\(sum_{$4}^2\\)</p>\n')
   })
+  it('can handle multiple dollors in formulas', function () {
+    md.render('if $a^{$2.00}$ then $b^{$3.00}$').should.eql('<p>if \\(a^{$2.00}\\) then \\(b^{$3.00}\\)</p>\n')
+  })
   it('should not be processed if space after first marker', function () {
     md.render('$ 1 *2* 3$').should.eql('<p>$ 1 <em>2</em> 3$</p>\n')
   })


### PR DESCRIPTION
## Problem
When using inline math delimiters `$` and you have dollars as content our markdown-it-mathjax plugin doesn't work like it should.  

I created an issue with the maintainer: https://github.com/classeur/markdown-it-mathjax/issues/10

## Changes
- I forked the source library. I opened an issue and PR at https://github.com/classeur/markdown-it-mathjax/pull/11 but it looks like a dead project.  So this might stay with us.
- Adds support for escaped dollars

## Follow up
I'll spread this around to our other tooling.